### PR TITLE
feat(integration): automatically re-execute schmersion if it is in a project's Gemfile

### DIFF
--- a/bin/schmersion
+++ b/bin/schmersion
@@ -3,6 +3,11 @@
 
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
+if [nil, '0', 'no', 'false'].include?(ENV['SCHMERSION_DISABLE_AUTO_BUNDLE_EXEC'])
+  require 'schmersion/auto_bundle_exec'
+  Schmersion::AutoBundleExec.when_bundled(:schmersion)
+end
+
 require 'schmersion'
 require 'swamp/cli'
 require 'git'

--- a/lib/schmersion/auto_bundle_exec.rb
+++ b/lib/schmersion/auto_bundle_exec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+module Schmersion
+  class AutoBundleExec
+
+    attr_reader :gems
+    attr_reader :pwd
+    attr_reader :bin
+    attr_reader :argv
+
+    def self.when_bundled(gems = [], pwd = Dir.pwd, bin = $PROGRAM_NAME, argv = ARGV)
+      return if ENV['BUNDLE_BIN_PATH']
+
+      gems = Array(gems).compact
+      return if gems.empty?
+
+      instance = new(gems, pwd, bin, argv)
+      return unless instance.bundled_dir?
+
+      instance.re_exec if gems.all? { |gem| instance.bundled?(gem) }
+    end
+
+    def initialize(gems, pwd, bin, argv)
+      @gems = gems
+      @pwd = pwd
+      @bin = bin
+      @argv = argv
+      check_dir
+    end
+
+    def bundled_dir?
+      @is_bundled_dir
+    end
+
+    def bundled?(gem)
+      gem_list.include?(" #{gem} ")
+    end
+
+    def re_exec
+      Kernel.exec(
+        { 'SCHMERSION_DISABLE_AUTO_BUNDLE_EXEC' => '1' },
+        'bundle', 'exec', bin, *argv
+      )
+    end
+
+    private
+
+    attr_reader :gem_list
+
+    def check_dir
+      @gem_list, status = Open3.capture2e('bundle list')
+      @is_bundled_dir = status.success?
+    end
+
+  end
+end


### PR DESCRIPTION
This ensures that even if schmersion is executed without `bundle exec`,
like the git hooks do, schmersion will re-run itself through `bundle
exec` if a `bundle list` lists the schmersion gem.

The criteria for re-executing itself with `bundle exec` are:

- The `SCHMERSION_DISABLE_AUTO_BUNDLE_EXEC` environment variable is not
  set.
- Is not already running via `bundle exec`, determined by check for
  presence of `BUNDLE_BIN_PATH` environment variable.
- Running `bundle list` from current directory returns a `0` (success)
  exit status, meaning it found a `Gemfile` to parse.
- The output from `bundle list` specifically contains the textual string
  `" schmersion "`, indicating it's listed on a line looking something
  like: `  * schmersion (1.0.2)`

If it does re-execute itself via `bundle exec`, it will also set the
`SCHMERSION_DISABLE_AUTO_BUNDLE_EXEC` environment to `1` as there's no
need for any part of the auto bundle exec code to run.